### PR TITLE
Recursive Cholesky functions (Init+update) added. Utility function added...

### DIFF
--- a/gurls/optimizers/rls_primalrecinitcholesky.m
+++ b/gurls/optimizers/rls_primalrecinitcholesky.m
@@ -1,0 +1,69 @@
+function [cfr] = rls_primalrecinitcholesky(X, y, opt)
+% rls_primalrecinitcholesky(X,y,opt)
+% computes a classifier for the primal formulation of RLS using the Cholesky decomposition of the covariance matrix. 
+% The variables necessary for further recursive update are stored in the
+% output structure.
+% The regularization parameter is set to the one found in opt.paramsel.
+% In case of multiclass problems, the regularizers need to be combined with the opt.singlelambda function.
+%
+% INPUTS:
+% -X: input data matrix
+% -y: labels matrix
+% -OPT: Options object with the following fields:
+%   fields that need to be set through previous gurls tasks:
+%		- paramsel.lambdas (set by the paramsel_* routines)
+%   fields with default values set through the defopt function:
+%		- singlelambda
+%       - opt.randfeats.D
+% 
+%   For more information on standard OPT fields
+%   see also defopt
+% 
+% OUTPUT: struct with the following fields:
+% -W: matrix of coefficient vectors of rls estimator for each class
+% -b: parameter vector
+% -C: empty matrix
+% -X: empty matrix
+% -R: Cholesky factor of the covariance matrix C
+% -XtX: empty matrix
+
+if isfield(opt.paramsel,'lambdas')
+    lambda = opt.singlelambda(opt.paramsel.lambdas);
+else
+    error('ERROR: No regularization parameter was found in opt.paramsel.lambdas.')
+end
+
+% Compute R from starting from XtX
+d = size(X,2);
+if isprop(opt,'kernel');
+    if isfield(opt.kernel,'XtX');
+        XtX = opt.kernel.XtX;
+    else
+        XtX = X'*X;
+    end
+    if isfield(opt.kernel,'Xty');
+        Xty = opt.kernel.Xty;
+    else
+        Xty = X'*y;
+    end
+    if isfield(opt.kernel,'n');
+        n = opt.kernel.n;
+    else
+        n = size(y,1);
+    end
+else
+    XtX = X'*X;
+    Xty = X'*y;
+end
+
+% This instruction computes R starting from XtX
+R = chol(XtX + (n*lambda)*eye(d));
+
+% Initialize parameter vector b and weights
+b = Xty;    % From previous training
+W = R\(R'\Xty);   % From previous matrix
+
+% Save in OPT
+cfr.R = R;
+cfr.W = W;
+cfr.b = b;

--- a/gurls/optimizers/rls_primalrecupdatecholesky.m
+++ b/gurls/optimizers/rls_primalrecupdatecholesky.m
@@ -1,0 +1,51 @@
+function [rls] = rls_primalrecupdatecholesky (X, y, opt)
+
+% rls_primalrecupdatecholesky(X,y,opt)
+% computes a classifier for the primal formulation of RLS, using a
+% recursive update of the right Cholesky factor R of covariance matrix C = XtX,
+% starting from an initial R found in OPT.RLS.
+%
+% INPUTS:
+% -X: input data matrix
+% -y: labels matrix
+% -OPT: Options object with the following fields:
+%   fields that need to be set through previous gurls tasks:
+%		- rls.W (set by rls_primalrecinitcholesky)
+%       - rls.R (set by rls_primalrecinitcholesky)
+%       - rls.b (set by rls_primalrecinitcholesky)
+% 
+%   For more information on standard OPT fields
+%   see also defopt
+% 
+% OUTPUT: struct with the following fields:
+% -W: matrix of coefficient vectors of rls estimator for each class
+% -Cinv: inverse of the regularized kernel matrix in the primal space
+% -C: empty matrix
+% -X: empty matrix
+
+W = opt.rls.W;
+R = opt.rls.R;
+b = opt.rls.b;
+
+n = size(X,1);
+
+% Sequence of rank-1 updates by application of Cholesky rank-1 updates
+for i = 1:n;
+    
+    % Update b
+    b = b + X(i,:)'*y(i,:);
+    
+    % Update Cholesky factor R
+    R = cholupdate(R,X(i,:)');
+
+end
+
+W = R\(R'\b);
+
+rls.b = b;
+rls.W = W;
+rls.C = [];
+rls.X = [];
+rls.XtX = [];
+rls.R = R;
+

--- a/gurls/utils/clearAllButBP.m
+++ b/gurls/utils/clearAllButBP.m
@@ -1,0 +1,10 @@
+%CLEARALLBUTBP: Script which clears all the workspace but breakpoints
+% Author: Raffaello Camoriano, raffaello.camoriano@iit.it
+
+s=dbstatus;
+save('myBreakpoints.mat', 's');
+clear all
+load('myBreakpoints.mat');
+delete('myBreakpoints.mat')
+dbstop(s);
+clear s;


### PR DESCRIPTION
The following GURLS functions have been added:
- rls_primalrecinitcholesky: Computes the upper Cholesky factor R of the covariance matrix C = XtX.
- rls_primalrecupdatecholesky: Performs a rank-k update of R, given k supervised samples.

These functions have been successfully tested in the experiments available at: https://github.com/Ommac/gurlsRRLSmatlab/tree/master/experiments

The following plot, produced by experiment 5 (https://github.com/Ommac/gurlsRRLSmatlab/blob/master/experiments/5_RRLS_bench_icubdyn_RF_nMSE/RRLS_bench_icubdyn_RF_nMSE.m), shows a comparison between the performance (nMSE) of a batch estimator and a recursive one using the proposed functions for performing 100 predictions and updates.

![res_pullreq](https://cloud.githubusercontent.com/assets/6359405/5063934/22905832-6dfb-11e4-8ac4-9c230ec463e6.jpg)

An utility script (clearAllButBP.m) for cleaning the workspace, keeping breakpoints unaltered, has alse been added to gurls/utils.
