### PR TITLE
Fix bugs in paramsel_siglam* and compatibility fixes for test files

### DIFF
--- a/gurls/confidence/conf_maxscore.m
+++ b/gurls/confidence/conf_maxscore.m
@@ -1,6 +1,6 @@
-function [out] = conf_maxscore(X,y, opt)
+function [out] = conf_maxscore(X, y, opt)
 
-%	conf_maxscore(opt)	
+%	conf_maxscore(opt)
 %	computes a codfidence estimation for the predicted class (i.e. highest scoring class).
 %	The difference between the highest scoring class and the second highest
 %	scoring class is considered.
@@ -13,6 +13,5 @@ function [out] = conf_maxscore(X,y, opt)
 %			- confidence 	: confidence estimate for the predicted label.
 %			- labels	: predicted label.
 
-		out = struct;
-		[out.confidence, out.labels] = max(opt.pred,[],2);
-
+out = struct;
+[out.confidence, out.labels] = max(opt.pred,[],2);

--- a/gurls/demo/demo_recursiveRLS.m
+++ b/gurls/demo/demo_recursiveRLS.m
@@ -28,10 +28,10 @@ Xtr = Xtr_tot(1:n0,:);
 ytr = ytr_tot(1:n0,:);
 
 name = [resdir '/recursiveRLS'];
-opt = defopt(name);
+opt = gurls_defopt(name);
 opt.seq = {'split:ho','paramsel:hoprimal','rls:primalrecinit'};
 opt.process{1} = [2,2,2];
-opt = gurls (Xtr, ytr, opt,1);
+opt = gurls(Xtr, ytr, opt,1);
 
 %% UPDATE: update RLS estimator recursively
 % update estimator recursively
@@ -50,14 +50,14 @@ opt.perf = perf_macroavg(Xte, yte, opt);
 
 %% compare with batch RLS
 name = [resdir '/standardRLSfixlambda'];
-optRLSfixlambda = defopt(name);
-optRLSfixlambda.newprop('paramsel.lambdas' , opt.paramsel.lambdas*n0/ntr_tot);
+optRLSfixlambda = gurls_defopt(name);
+optRLSfixlambda.newprop('paramsel.lambdas', opt.paramsel.lambdas*n0/ntr_tot);
 
 optRLSfixlambda.seq = {'rls:primal','pred:primal','perf:macroavg'};
 optRLSfixlambda.process{1} = [2,0,0];
 optRLSfixlambda.process{2} = [3,2,2];
-optRLSfixlambda = gurls (Xtr_tot, ytr_tot, optRLSfixlambda,1);
-optRLSfixlambda = gurls (Xte, yte, optRLSfixlambda,2);
+optRLSfixlambda = gurls(Xtr_tot, ytr_tot, optRLSfixlambda,1);
+optRLSfixlambda = gurls(Xte, yte, optRLSfixlambda,2);
 
 % check that solutions coincide
 disp('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')

--- a/gurls/demo/demo_recursiveRLSwRetrain.m
+++ b/gurls/demo/demo_recursiveRLSwRetrain.m
@@ -28,13 +28,13 @@ Xtr = Xtr_tot(1:n0,:);
 ytr = ytr_tot(1:n0,:);
 
 name = [resdir '/recursiveRLS'];
-opt = defopt(name);
+opt = gurls_defopt(name);
 opt.kernel.XtX = Xtr'*Xtr;
 opt.kernel.Xty = Xtr'*ytr;
 opt.kernel.n = size(ytr,1);
 opt.seq = {'split:ho','paramsel:hoprimal','rls:primalrecinit'};
 opt.process{1} = [2,2,2];
-opt = gurls (Xtr, ytr, opt,1);
+opt = gurls(Xtr, ytr, opt,1);
 
 Xva = Xtr(opt.split{1}.va,:);
 yva = ytr(opt.split{1}.va,:);
@@ -64,18 +64,18 @@ opt.perf = perf_macroavg(Xte, yte, opt);
 
 %% RETRAIN: retrain RLS and test
 
-optRetrained = defopt(name);
+optRetrained = gurls_defopt(name);
 optRetrained.kernel = opt.kernel;
 nva = size(yva,1);
-optRetrained.newprop( 'split', {});
+optRetrained.newprop('split', {});
 optRetrained.split{1}.tr = zeros(opt.kernel.n - nva , 1);
 optRetrained.split{1}.va = 1:nva;
 
 optRetrained.seq = {'paramsel:hoprimal','rls:primalrecinit','pred:primal','perf:macroavg'};
 optRetrained.process{1} = [2,2,0,0];
 optRetrained.process{2} = [3,3,2,2];
-optRetrained = gurls (Xva, yva, optRetrained,1);
-optRetrained = gurls (Xte, yte, optRetrained,2);
+optRetrained = gurls(Xva, yva, optRetrained,1);
+optRetrained = gurls(Xte, yte, optRetrained,2);
  
 disp('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
 disp('maximum difference between predicted Ys when using parameter chosen on the first batch or globally:')

--- a/gurls/gurls.m
+++ b/gurls/gurls.m
@@ -66,16 +66,16 @@ end
 seq = opt.seq;
 % Load and copy
 
-if exist(opt.savefile) == 2
-	t = load(opt.savefile);
-	if isprop(t.opt,'time');
-		opt.time = t.opt.time;
-	end	
+if exist(opt.savefile, 'file') == 2
+    t = load(opt.savefile);
+    if isprop(t.opt,'time');
+        opt.time = t.opt.time;
+    end
 else
     if ~isequal(opt.name,'')
         fprintf('Could not load %s. Starting from scratch.\n', opt.savefile);
     end
-end	
+end
 %try
 %	t = load(opt.savefile);
 %	if isfield(t.opt,'time')

--- a/gurls/kernels/kernel_chisquared.m
+++ b/gurls/kernels/kernel_chisquared.m
@@ -1,4 +1,4 @@
-function [kernel] = kernel_chisquared(X,y, opt)
+function [kernel] = kernel_chisquared(X, y, opt)
 % kernel_chisquared(opt)
 % Computes the Kernel matrix for chi-squared kernel.		
 %
@@ -9,6 +9,9 @@ function [kernel] = kernel_chisquared(X,y, opt)
 % -type: 'chisquared'
 % -K: kernel matrix
 
+if ~isprop(opt,'kernel')
+    opt.newprop('kernel', struct());
+end
 kernel = opt.kernel;
 kernel.type = 'chisquared';
 

--- a/gurls/kernels/kernel_linear.m
+++ b/gurls/kernels/kernel_linear.m
@@ -1,4 +1,4 @@
-function [kernel] = kernel_linear(X,y, opt)
+function [kernel] = kernel_linear(X, y, opt)
 % kernel_linear(OPT)
 % Computes the Kernel matrix for a linear model.		
 %
@@ -8,6 +8,18 @@ function [kernel] = kernel_linear(X,y, opt)
 % OUTPUT: struct with the following fields:
 % -type: 'linear'
 % -K: kernel matrix
+
+% if isprop(opt,'kernel')
+%     kernel = opt.kernel; % lets not overwrite existing parameters.
+%     % unless they have the same name
+% else
+%     kernel = struct();
+% end
+
+if ~isprop(opt,'kernel')
+    opt.newprop('kernel', struct());
+end
+
 kernel = opt.kernel;
 kernel.type = 'linear';
 kernel.kerrange = 1;

--- a/gurls/kernels/kernel_rbf.m
+++ b/gurls/kernels/kernel_rbf.m
@@ -1,4 +1,4 @@
-function [kernel] = kernel_rbf(X,y, opt)
+function [kernel] = kernel_rbf(X, y, opt)
 
 % 	kernel_rbf(opt)
 %	Computes the kernel matrix for a Gaussian kernel.
@@ -12,6 +12,9 @@ function [kernel] = kernel_rbf(X,y, opt)
 %		-type: 'rbf'
 %		-K: kernel matrix
 
+if ~isprop(opt,'kernel')
+    opt.newprop('kernel', struct());
+end
 kernel = opt.kernel;
 
 if ~isfield(kernel,'distance')

--- a/gurls/kernels/predkernel_traintest.m
+++ b/gurls/kernels/predkernel_traintest.m
@@ -1,4 +1,4 @@
-function [fk] = predkernel_traintest(X,y, opt)
+function [fk] = predkernel_traintest(X, y, opt)
 % predkernel_traintest(OPT)
 % Computes the kernel matrix between the training points and the
 % test points. It can be used by pred_dual.
@@ -26,8 +26,8 @@ switch opt.kernel.type
 			opt.newprop('predkernel', struct());
 			opt.predkernel.type = 'rbf';
 		end
-		if ~isfield(opt.predkernel,'distance')
-			opt.predkernel.distance = square_distance(X',opt.rls.X');
+        if ~isfield(opt.predkernel,'distance')
+            opt.predkernel.distance = square_distance(X',opt.rls.X');
         end
 		fk.distance = opt.predkernel.distance;
 			%D = -(opt.finalkernel.distance.^2);
@@ -44,12 +44,12 @@ switch opt.kernel.type
 		fk.type = 'linear';
 		fk.K = X*opt.rls.X';
 	case {'chisquared'}
-		for i = 1:size(X,1)
-			for j = 1:size(opt.rls.X,1)
-				fk.K(i,j) = sum(...
-					( (X(i,:) - opt.rls.X(j,:)).^2 ) ./ ...
-					( 0.5*(X(i,:) + opt.rls.X(j,:)) + eps));
-			end
+        for i = 1:size(X,1)
+            for j = 1:size(opt.rls.X,1)
+                fk.K(i,j) = sum(...
+                    ( (X(i,:) - opt.rls.X(j,:)).^2 ) ./ ...
+                    ( 0.5*(X(i,:) + opt.rls.X(j,:)) + eps));
+            end
         end
 
 	case {'datatype'}

--- a/gurls/paramsel/paramsel_hodual.m
+++ b/gurls/paramsel/paramsel_hodual.m
@@ -1,7 +1,7 @@
 function [vout] = paramsel_hodual(X,y,opt)
 % paramsel_hopdual(X,y, OPT)
 % Performs parameter selection when the dual formulation of RLS is used.
-% The hold-out approach is used. 
+% The hold-out approach is used.
 % The performance measure specified by opt.hoperf is maximized.
 %
 % INPUTS:
@@ -13,95 +13,95 @@ function [vout] = paramsel_hodual(X,y,opt)
 %		- nlambda
 %		- smallnumber
 %		- hoperf
-%               - nholdouts
+%       - nholdouts
 %		- kernel.type
 %
 %   For more information on standard OPT fields
 %   see also defopt
-% 
+%
 % OUTPUTS: structure with the following fields:
-% -lambdas_round: cell array (opt.nholdoutsX1). For each split a cell contains the 
-%       values of the regularization parameter lambda minimizing the 
+% -lambdas_round: cell array (opt.nholdoutsX1). For each split a cell contains the
+%       values of the regularization parameter lambda minimizing the
 %       validation error for each class.
-% -forho: cell array (opt.nholdoutsX1). For each split a cell contains a matrix 
+% -forho: cell array (opt.nholdoutsX1). For each split a cell contains a matrix
 %       with the validation error for each lambda guess and for each class
-% -guesses: cell array (opt.nholdoutsX1). For each split a cell contains an 
+% -guesses: cell array (opt.nholdoutsX1). For each split a cell contains an
 %       array of guesses for the regularization parameter lambda
 % -lambdas: mean of the optimal lambdas across splits
 
 if isprop(opt,'paramsel')
-	vout = opt.paramsel; % lets not overwrite existing parameters.
-			      		 % unless they have the same name
+    vout = opt.paramsel; % lets not overwrite existing parameters.
+    % unless they have the same name
 else
     opt.newprop('paramsel', struct());
 end
 
 for nh = 1:opt.nholdouts
-	if strcmp(class(opt.split),'cell')
-		tr = opt.split{nh}.tr;
-		va = opt.split{nh}.va;
-	else	
-		tr = opt.split.tr;
-		va = opt.split.va;
-	end	
-	
-	[n,T]  = size(y(tr,:));
-	
-	if strcmp(opt.kernel.type,'linear')
-		d = size(X(tr,:),2);
+    if iscell(opt.split)
+        tr = opt.split{nh}.tr;
+        va = opt.split{nh}.va;
+    else
+        tr = opt.split.tr;
+        va = opt.split.va;
+    end
+    
+    [n,T]  = size(y(tr,:));
+    
+    if strcmp(opt.kernel.type,'linear')
+        d = size(X(tr,:),2);
         r = min(n,d);
     else
         r = n;
-	end
-	
-	[Q,L] = eig(opt.kernel.K(tr,tr));
-	Q = double(Q);
-	L = double(diag(L));
-	
-	tot = opt.nlambda;
-	guesses = paramsel_lambdaguesses(L, r, n, opt);
-	
-	ap = zeros(tot,T);
-	QtY = Q'*y(tr,:);
+    end
+    
+    [Q,L] = eig(opt.kernel.K(tr,tr));
+    Q = double(Q);
+    L = double(diag(L));
+    
+    tot = opt.nlambda;
+    guesses = paramsel_lambdaguesses(L, r, n, opt);
+    
+    ap = zeros(tot,T);
+    QtY = Q'*y(tr,:);
     
     if ~isprop(opt, 'rls')
         opt.newprop('rls', struct());
     end
     
-	for i = 1:tot
-		%%%%%% REPLICATING CODE FROM RLS_DUAL %%%%%%%%
-		opt.rls.C = rls_eigen(Q,L,QtY,guesses(i),n);
-		%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-	
-		if size(X,1) > 0
-			Xva = X(va,:);
-			opt.rls.X = X(tr,:);
-		else
-			Xva = [];
-		end
-	
-		yva = y(va,:);
-		if strcmp(opt.kernel.type,'linear')
-			opt.rls.W = X(tr,:)'*opt.rls.C; 
-		else 
-			opt.predkernel.K = opt.kernel.K(va,tr);
-		end	
-	
-		opt.newprop('pred', pred_dual(Xva,yva,opt));
-		opt.newprop('perf', opt.hoperf(Xva,yva,opt));
-		%p{i} = perf(scores,yho,{'precrec'});
-		for t = 1:T
-			ap(i,t) = opt.perf.forho(t);
-		end	
-	end	
-	[dummy,idx] = max(ap,[],1);	
-	vout.lambdas_round{nh} = guesses(idx);
-	vout.perf{nh} = ap;
-	vout.guesses{nh} = guesses;
-end	
+    for i = 1:tot
+        %%%%%% REPLICATING CODE FROM RLS_DUAL %%%%%%%%
+        opt.rls.C = rls_eigen(Q,L,QtY,guesses(i),n);
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        
+        if size(X,1) > 0
+            Xva = X(va,:);
+            opt.rls.X = X(tr,:);
+        else
+            Xva = [];
+        end
+        
+        yva = y(va,:);
+        if strcmp(opt.kernel.type,'linear')
+            opt.rls.W = X(tr,:)'*opt.rls.C;
+        else
+            opt.newprop('predkernel.K', opt.kernel.K(va,tr));
+        end
+        
+        opt.newprop('pred', pred_dual(Xva,yva,opt));
+        opt.newprop('perf', opt.hoperf(Xva,yva,opt));
+        %p{i} = perf(scores,yho,{'precrec'});
+        for t = 1:T
+            ap(i,t) = opt.perf.forho(t);
+        end
+    end
+    [~, idx] = max(ap,[],1);
+    vout.lambdas_round{nh} = guesses(idx);
+    vout.perf{nh} = ap;
+    vout.guesses{nh} = guesses;
+end
 if numel(vout.lambdas_round) > 1
-	lambdas = cell2mat(vout.lambdas_round');
-	vout.lambdas = median(lambdas);
+    lambdas = cell2mat(vout.lambdas_round');
+    vout.lambdas = median(lambdas);
 else
-	vout.lambdas = vout.lambdas_round{1};
+    vout.lambdas = vout.lambdas_round{1};
 end

--- a/gurls/paramsel/paramsel_hodualr.m
+++ b/gurls/paramsel/paramsel_hodualr.m
@@ -1,4 +1,4 @@
-function [vout] = paramsel_hodualr(X,y, opt)
+function [vout] = paramsel_hodualr(X, y, opt)
 % paramsel_hopdualr(X,y, OPT)
 % Performs parameter selection when the dual formulation of RLS is used.
 % The hold-out approach is used. 
@@ -38,16 +38,14 @@ else
     opt.newprop('paramsel', struct());
 end
 
-savevars = [];
 for nh = 1:opt.nholdouts
-	if strcmp(class(opt.split),'cell')
+	if iscell(opt.split)
 		tr = opt.split{nh}.tr;
 		va = opt.split{nh}.va;
 	else	
 		tr = opt.split.tr;
 		va = opt.split.va;
 	end	
-
 
 	[n,T]  = size(y(tr,:));
 	
@@ -83,7 +81,7 @@ for nh = 1:opt.nholdouts
 		if strcmp(opt.kernel.type,'linear')
 			opt.rls.W = X(tr,:)'*opt.rls.C; 
 		else
-			opt.predkernel.K = opt.kernel.K(va,tr);
+            opt.newprop('predkernel.K', opt.kernel.K(va,tr));
 		end	
 	
 		opt.newprop('pred',pred_dual(Xva,yva,opt));

--- a/gurls/paramsel/paramsel_hoprimal.m
+++ b/gurls/paramsel/paramsel_hoprimal.m
@@ -1,4 +1,4 @@
-function [vout] = paramsel_hoprimal(X,y,opt)
+function [vout] = paramsel_hoprimal(X, y, opt)
 % paramsel_hoprimal(X,Y,OPT)
 % Performs parameter selection when the primal formulation of RLS is used.
 % The hold-out approach is used. 
@@ -12,7 +12,7 @@ function [vout] = paramsel_hoprimal(X,y,opt)
 %		- nlambda
 %		- smallnumber
 %		- hoperf
-%       	- nholdouts
+%       - nholdouts
 %
 %   For more information on standard OPT fields
 %   see also defopt
@@ -28,8 +28,8 @@ function [vout] = paramsel_hoprimal(X,y,opt)
 % -lambdas: mean of the optimal lambdas across splits
 
 if isprop(opt,'paramsel')
-	vout = opt.paramsel; % lets not overwrite existing parameters.
-			      		 % unless they have the same name
+    vout = opt.paramsel; % lets not overwrite existing parameters.
+    % unless they have the same name
     
     if isfield(opt.paramsel,'perf')
         vout = rmfield(vout,'perf');
@@ -41,7 +41,6 @@ else
     opt.newprop('paramsel', struct());
 end
 
-savevars = [];
 
 %verify if matrix XtX has already been computed (especially for online RLS)
 if isprop(opt,'kernel');
@@ -65,7 +64,7 @@ d = size(X,2);
 T = size(y,2);
 
 for nh = 1:opt.nholdouts
-	if strcmp(class(opt.split),'cell')
+	if iscell(opt.split)
 		tr = opt.split{nh}.tr;
 		va = opt.split{nh}.va;
 	else	
@@ -98,7 +97,7 @@ for nh = 1:opt.nholdouts
 			ap(i,t) = opt.perf.forho(t);
 		end	
 	end	
-	[dummy,idx] = max(ap,[],1);	
+	[dummy, idx] = max(ap,[],1);	
 	vout.lambdas_round{nh} = guesses(idx);
 	vout.perf{nh} = ap;
 	vout.guesses{nh} = guesses;

--- a/gurls/paramsel/paramsel_hoprimalr.m
+++ b/gurls/paramsel/paramsel_hoprimalr.m
@@ -1,4 +1,4 @@
-function [vout] = paramsel_hoprimalr(X,y, opt)
+function [vout] = paramsel_hoprimalr(X, y, opt)
 % paramsel_hoprimalr(X,y, OPT)
 % Performs parameter selection when the primal formulation of RLS is used.
 % The hold-out approach is used. 
@@ -34,10 +34,9 @@ if isprop(opt,'paramsel')
 else
     opt.newprop('paramsel', struct());
 end
-savevars = [];
 
 for nh = 1:opt.nholdouts
-	if strcmp(class(opt.split),'cell')
+	if iscell(opt.split)
 		tr = opt.split{nh}.tr;
 		va = opt.split{nh}.va;
 	else	
@@ -46,7 +45,7 @@ for nh = 1:opt.nholdouts
 	end	
 
 	[n,d] = size(X(tr,:));
-	[n,T]  = size(y(tr,:));
+	[n,T] = size(y(tr,:));
 	
 	K = X(tr,:)'*X(tr,:);
 	

--- a/gurls/paramsel/paramsel_loocvdual.m
+++ b/gurls/paramsel/paramsel_loocvdual.m
@@ -62,5 +62,5 @@ end
 
 [dummy,idx] = max(ap,[],1);	
 vout.lambdas = 	guesses(idx);
-vout.perf = 	ap;
+vout.perf = ap;
 vout.guesses = 	guesses;

--- a/gurls/paramsel/paramsel_loocvprimal.m
+++ b/gurls/paramsel/paramsel_loocvprimal.m
@@ -1,4 +1,4 @@
-function vout = paramsel_loocvprimal(X,y, opt)
+function vout = paramsel_loocvprimal(X, y, opt)
 % paramsel_loocvprimal(X,y, OPT)
 % Performs parameter selection when the primal formulation of RLS is used.
 % The leave-one-out approach is used.

--- a/gurls/paramsel/paramsel_siglam.m
+++ b/gurls/paramsel/paramsel_siglam.m
@@ -1,5 +1,5 @@
 function vout = paramsel_siglam(X, y, opt)
-% paramsel_siglam(X,y, OPT)
+% paramsel_siglam(X, y, OPT)
 % Performs parameter selection when the dual formulation of RLS is used.
 % The leave-one-out approach is used.
 % It selects both the regularization parameter lambda and the kernel parameter sigma.
@@ -26,13 +26,18 @@ function vout = paramsel_siglam(X, y, opt)
 %savevars = {'LOOSQE','M','sigmas','guesses'};
 
 if isprop(opt,'paramsel')
-	vout = opt.paramsel; % lets not overwrite existing parameters.
-			      		 % unless they have the same name
+    vout = opt.paramsel; % lets not overwrite existing parameters.
+    % unless they have the same name
 else
     opt.newprop('paramsel', struct());
 end
 
-[~,T]  = size(y);
+% case: sigma was prev. set & paramsel_siglam is called to re-compute it
+if isfield(opt.paramsel, 'sigma')
+    opt.paramsel = rmfield(opt.paramsel, 'sigma');
+end
+
+[~, T]  = size(y);
 
 if ~isprop(opt,'kernel')
     opt.newprop('kernel', struct());
@@ -62,8 +67,8 @@ end
 
 M = sum(PERF,3); % sum over classes
 
-[dummy,i] = max(M(:));
-[m,n] = ind2sub(size(M),i);
+[dummy, i] = max(M(:));
+[m, n] = ind2sub(size(M),i);
 
 % opt sigma
 vout.sigma = opt.kernel.kerrange(m);

--- a/gurls/paramsel/paramsel_siglamho.m
+++ b/gurls/paramsel/paramsel_siglamho.m
@@ -1,5 +1,5 @@
-function vout = paramsel_siglamho(X,y,opt)
-% paramsel_siglam(X,y, OPT)
+function vout = paramsel_siglamho(X, y, opt)
+% paramsel_siglamho(X, y, OPT)
 % Performs parameter selection when the dual formulation of RLS is used.
 % The hold-out approach is used.
 % It selects both the regularization parameter lambda and the kernel parameter sigma.
@@ -28,6 +28,11 @@ if isprop(opt,'paramsel')
 			      		 % unless they have the same name
 else
     opt.newprop('paramsel', struct());
+end
+
+% case: sigma was prev. set & paramsel_siglam is called to re-compute it
+if isfield(opt.paramsel, 'sigma')
+    opt.paramsel = rmfield(opt.paramsel, 'sigma');
 end
 
 [~,T]  = size(y);

--- a/gurls/pred/pred_dual.m
+++ b/gurls/pred/pred_dual.m
@@ -17,9 +17,9 @@ function [scores] = pred_dual(X,y, opt)
 % OUTPUT:
 % -scores: matrix of predicted labels
 
-if ~strcmp(opt.kernel.type , 'linear') && isprop(opt,'predkernel')
+if ~strcmp(opt.kernel.type, 'linear') && isprop(opt, 'predkernel')
 	scores = opt.predkernel.K*opt.rls.C;
-elseif strcmp(opt.kernel.type , 'linear')
+elseif strcmp(opt.kernel.type, 'linear')
 	scores = pred_primal(X, y, opt);
 else	
 	error('Please provide a predkernel');

--- a/gurls/pred/pred_primal.m
+++ b/gurls/pred/pred_primal.m
@@ -1,6 +1,6 @@
-function [scores] = pred_primal(X,y, opt)
+function [scores] = pred_primal(X, y, opt)
 % pred_primal(opt)
-% computes the predictions of the linear classifier stored in opt.rls.W 
+% computes the predictions of the linear classifier stored in opt.rls.W
 % on the samples passed in the X matrix.
 %
 % INPUTS:
@@ -8,7 +8,7 @@ function [scores] = pred_primal(X,y, opt)
 %   -X: input data matrix
 %   fields that need to be set through previous gurls tasks:
 %		- rls.W (set by the rls_* routines)
-% 
+%
 % OUTPUT:
 % -scores: matrix of predicted labels
-	scores = X*opt.rls.W;	
+scores = X*opt.rls.W;

--- a/gurls/utils/rls_primal_driver.m
+++ b/gurls/utils/rls_primal_driver.m
@@ -3,7 +3,7 @@ function [W] = rls_primal_driver(XtX, Xty, n, lambda)
 % Utility function used by rls_primal
 % 
 % INPUTS:
-% -XtX: simmetric dxd square matrix
+% -XtX: symmetric dxd square matrix
 % -Xty: dxT matrix
 % -n: number of training samples
 % -lambda: regularization parameter

--- a/gurls/utils/test_driver.m
+++ b/gurls/utils/test_driver.m
@@ -2,7 +2,7 @@ function [] = test_driver(task,dirname,opt)
 
     disp(dirname)
 
-    if nargin<3; opt = struct(); end
+    if nargin<3; opt = struct(); end    
 
     opt.hoMOnline = 0;
     opt.nlambda = load('nlambda.txt');
@@ -48,6 +48,7 @@ function [] = test_driver(task,dirname,opt)
                 opt.split = split;
             end
             opt = addopt(opt,'kernel',allfiles,dirname,filein);
+            opt = checkopt(opt);
             vout = task(X,y,opt);
             saveopt(vout,'paramsel',dirname,fileout)
         case 'rls'
@@ -60,7 +61,8 @@ function [] = test_driver(task,dirname,opt)
         case 'kernel'
             X = load('Xtr.txt');
             y = load('ytr.txt');
-            opt = addopt(opt,'paramsel',allfiles,dirname,filein);        
+            opt = addopt(opt,'paramsel',allfiles,dirname,filein);  
+            opt = checkopt(opt);
             vout = task(X,y,opt);
             saveopt(vout,'kernel',dirname,fileout)
         case 'predkernel'
@@ -68,7 +70,8 @@ function [] = test_driver(task,dirname,opt)
             y = load('ytr.txt');
             opt = addopt(opt,'paramsel',allfiles,dirname,filein);        
             opt = addopt(opt,'rls',allfiles,dirname,filein);             
-            opt = addopt(opt,'kernel',allfiles,dirname,filein);        
+            opt = addopt(opt,'kernel',allfiles,dirname,filein); 
+            opt = checkopt(opt);
             vout = task(X,y,opt);
             saveopt(vout,'predkernel',dirname,fileout)
         case 'pred'
@@ -77,6 +80,7 @@ function [] = test_driver(task,dirname,opt)
             opt = addopt(opt,'rls',allfiles,dirname,filein);        
             opt = addopt(opt,'predkernel',allfiles,dirname,filein);      
             opt = addopt(opt,'kernel',allfiles,dirname,filein);
+            opt = checkopt(opt);
             vout = task(X,y,opt);
             saveopt(vout,'pred',dirname,fileout)
         case 'perf'
@@ -92,6 +96,7 @@ function [] = test_driver(task,dirname,opt)
             vout = task(X,y,opt);
             saveopt(vout,'conf',dirname,fileout)
     end
+       
 end
 
 function opt = addopt(opt,optfield,allfiles,dirname,typesfile)
@@ -195,4 +200,12 @@ function []  = savevar(var,filename,typesfile)
     fprintf(fid,'%s %s\n',filename,vartype);
     fclose(fid);
     
+end
+
+function opt = checkopt(opt)
+% Checking compatibility, transforming to new GURLS opt
+if ~isa(opt, 'GurlsOptions')
+    warning('Compatibility mode with GURLS 1.0');
+    opt = GurlsOptions(opt);
+end
 end


### PR DESCRIPTION
- Bugs in paramsel_siglam and paramsel_siglamho when retraining with opt.paramsel.sigma present: when retraining on the same set, with RBF and asking to re-compute sigma/lambda, even though sigma is not recomputed (due to a check in kernel_rbf), the returned value corresponds to a wrong sigma in opt.kernel.kerrange.
- Compatibility checks in kernel_linear.m, kernel_rbf.m, kernel_chisquared for newprop when opt is passed in. Previously crashed in testall.m.
- Compatibility fixes on test_driver.m and testall.m to run (for gurls upgrade). Now testall.m runs regularily (and in total) as before. 
- All files under gurls/test and gurls/demo now run normally. 
