### PR TITLE
SVM Subgradient Method

### DIFF
--- a/gurls/defopt.m
+++ b/gurls/defopt.m
@@ -67,6 +67,9 @@ function opt = defopt(expname)
     opt.epochs = 4;
     opt.subsize = 50;
     opt.calibfile = 'foo';
+    
+    %% Subgradient
+    opt.Niter= 100;
 
     %% Random features options
     opt.randfeats = struct();

--- a/gurls/defopt.m
+++ b/gurls/defopt.m
@@ -70,6 +70,7 @@ function opt = defopt(expname)
     
     %% Subgradient
     opt.Niter= 100;
+    opt.gammafunc = @(x) power(x,-1);
 
     %% Random features options
     opt.randfeats = struct();

--- a/gurls/demo/demo_svmsubgradient.m
+++ b/gurls/demo/demo_svmsubgradient.m
@@ -1,9 +1,6 @@
 % DEMO OF THE SVM SUBGRADIENT METHOD COMPARED TO DUAL FORMULATION
 % adapted from gurlsdemo.m
 
-% Clear and close everything
-clear all; close all;
-
 % Use either the 'breastcancer' or 'yeast' datasets
 dataset = 'yeast';
 if strcmp(dataset,'breastcancer')

--- a/gurls/demo/demo_svmsubgradient.m
+++ b/gurls/demo/demo_svmsubgradient.m
@@ -11,8 +11,8 @@ elseif strcmp(dataset,'yeast')
 end
 
 % List the methods to use
-% models = {'linsvmsub','rbfsvmsub','rbfho','rbfloo'};
-models = {'linsvmsub','rbfsvmsub','rbfho'};
+% pipelines = {'linsvmsub','rbfsvmsub','rbfho','rbfloo'};
+pipelines = {'linsvmsub','rbfsvmsub','rbfho'};
 
 % Number of trials to run each method
 n = 5;
@@ -20,10 +20,10 @@ n = 5;
 res_root = fullfile(gurls_root, 'demo'); % location where res files are stored
 
 for r = 1:n
-    strind = strmatch('linsvmsub',models);
+    strind = strmatch('linsvmsub',pipelines);
     if ~isempty(strind)
         % Gaussian kernel, SVM Subgradient, Hold Out cross validation to select lambda
-        name = [models{strind} '_' num2str(r)];
+        name = [pipelines{strind} '_' num2str(r)];
         opt = defopt(name);
         opt.seq = {'split:ho', 'kernel:linear', 'paramsel:hodual', 'rls:svmsubgradient', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
         opt.process{1} = [2,2,2,2,0,0,0];
@@ -34,10 +34,10 @@ for r = 1:n
         gurls(Xte, yte, opt, 2);
     end
 
-    strind = strmatch('rbfsvmsub',models);
+    strind = strmatch('rbfsvmsub',pipelines);
     if ~isempty(strind)
         % Gaussian kernel, SVM Subgradient, Hold Out cross validation to select lambda and the Kernel width sigma
-        name = [models{strind} '_' num2str(r)];
+        name = [pipelines{strind} '_' num2str(r)];
         opt = defopt(name);
         opt.seq = {'split:ho', 'paramsel:siglamho', 'kernel:rbf', 'rls:svmsubgradient', 'predkernel:traintest', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
         opt.process{1} = [2,2,2,2,0,0,0,0];
@@ -48,10 +48,10 @@ for r = 1:n
         gurls(Xte, yte, opt, 2);
     end
 
-    strind = strmatch('rbfho',models);
+    strind = strmatch('rbfho',pipelines);
     if ~isempty(strind)
         % Gaussian kernel, (dual formulation), Hold Out cross validation to select lambda and the Kernel width sigma
-        name = [models{strind} '_' num2str(r)];
+        name = [pipelines{strind} '_' num2str(r)];
         opt = defopt(name);
         opt.seq = {'split:ho', 'paramsel:siglamho', 'kernel:rbf', 'rls:dual', 'predkernel:traintest', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
         opt.process{1} = [2,2,2,2,0,0,0,0];
@@ -60,10 +60,10 @@ for r = 1:n
         gurls(Xte, yte, opt, 2); 
     end
     
-    strind = strmatch('rbfloo',models);
+    strind = strmatch('rbfloo',pipelines);
     if ~isempty(strind)
         % Gaussian kernel, (dual formulation), Leave One Out cross validation to select lambda and the Kernel width sigma
-        name = [models{strind} '_' num2str(r)];
+        name = [pipelines{strind} '_' num2str(r)];
         opt = defopt(name);
         opt.seq = {'paramsel:siglam', 'kernel:rbf', 'rls:dual', 'predkernel:traintest', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
         opt.process{1} = [2,2,2,0,0,0,0];
@@ -79,7 +79,7 @@ end
 %	- fields: which fields of opt to display (as many plots as the elements of fields will be generated).
 %	- plotopt: a structure containing various text labels for the plots.
 
-nRuns = n*ones(1,size(models,2));
+nRuns = n*ones(1,size(pipelines,2));
 fields = {'perf.ap', 'perf.acc'};
 plotopt.titles = {'Model Comparison - Accuracy', 'Model Comparison - Precision'};
 
@@ -91,9 +91,9 @@ elseif strcmp(dataset,'yeast')
 end
 
 % Generates "per-class" plots
-summary_plot(models, fields, nRuns, plotopt, res_root)
+summary_plot(pipelines, fields, nRuns, plotopt, res_root)
 % Generates "global" plots
-summary_overall_plot(models, fields, nRuns, plotopt, res_root)
+summary_overall_plot(pipelines, fields, nRuns, plotopt, res_root)
 % Plots times taken by each step of the pipeline for performance reference.
-plot_times(models, nRuns, res_root)
+plot_times(pipelines, nRuns, res_root)
 

--- a/gurls/demo/demo_svmsubgradient.m
+++ b/gurls/demo/demo_svmsubgradient.m
@@ -11,7 +11,8 @@ elseif strcmp(dataset,'yeast')
 end
 
 % List the methods to use
-models = {'linsvmsub','rbfsvmsub','rbfho','rbfloo'};
+% models = {'linsvmsub','rbfsvmsub','rbfho','rbfloo'};
+models = {'linsvmsub','rbfsvmsub','rbfho'};
 
 % Number of trials to run each method
 n = 5;

--- a/gurls/demo/demo_svmsubgradient.m
+++ b/gurls/demo/demo_svmsubgradient.m
@@ -10,10 +10,10 @@ elseif strcmp(dataset,'yeast')
     load(fullfile(gurls_root, 'demo/data/yeast_data.mat'));
 end
 
-% List the models to use
+% List the methods to use
 models = {'linsvmsub','rbfsvmsub','rbfho','rbfloo'};
 
-% Number of iterations
+% Number of trials to run each method
 n = 5;
 
 res_root = fullfile(gurls_root, 'demo/demodata'); % location where res files are stored
@@ -27,7 +27,8 @@ for r = 1:n
         opt.seq = {'split:ho', 'kernel:linear', 'paramsel:hodual', 'rls:svmsubgradient', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
         opt.process{1} = [2,2,2,2,0,0,0];
         opt.process{2} = [3,3,3,3,2,2,2];
-        opt.epochs = 100;
+        opt.Niter = 200;
+%         opt.gammafunc = @(x) power(x,-.5);
         gurls(Xtr, ytr, opt, 1);
         gurls(Xte, yte, opt, 2);
     end
@@ -40,7 +41,8 @@ for r = 1:n
         opt.seq = {'split:ho', 'paramsel:siglamho', 'kernel:rbf', 'rls:svmsubgradient', 'predkernel:traintest', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
         opt.process{1} = [2,2,2,2,0,0,0,0];
         opt.process{2} = [3,3,3,3,2,2,2,2];
-        opt.epochs = 100;
+        opt.Niter = 200;
+%         opt.gammafunc = @(x) power(x,-.5);
         gurls(Xtr, ytr, opt, 1);
         gurls(Xte, yte, opt, 2);
     end
@@ -76,7 +78,7 @@ end
 %	- fields: which fields of opt to display (as many plots as the elements of fields will be generated).
 %	- plotopt: a structure containing various text labels for the plots.
 
-nRuns = n*ones(1,length(models));
+nRuns = n*ones(1,size(models,2));
 fields = {'perf.ap', 'perf.acc'};
 plotopt.titles = {'Model Comparison - Accuracy', 'Model Comparison - Precision'};
 

--- a/gurls/demo/demo_svmsubgradient.m
+++ b/gurls/demo/demo_svmsubgradient.m
@@ -1,0 +1,95 @@
+clear all;
+close all;
+
+% dataset = 'breastcancer';
+dataset = 'yeast';
+if strcmp(dataset,'breastcancer')
+    load(fullfile(gurls_root, 'demo/data/breastcancer_data.mat')); 
+    ytr = ytr*2-1; yte = yte*2-1; % Need to change output to {-1,1}  
+elseif strcmp(dataset,'yeast')
+    load(fullfile(gurls_root, 'demo/data/yeast_data.mat'));
+end
+
+% filestr = {'linsvmsub','rbfsvmsub'};
+filestr = {'linsvmsub','rbfsvmsub','rbfho','rbfloo'};
+n = 5;
+
+res_root = fullfile(gurls_root, 'demo/demodata'); % location where res files are stored
+
+for r = 1:n
+    strind = strmatch('linsvmsub',filestr);
+    if ~isempty(strind)
+        % Gaussian kernel, SVM Subgradient, Hold Out cross validation to select lambda and the Kernel width sigma
+        name = [filestr{strind} '_' num2str(r)];
+        opt = defopt(name);
+        opt.seq = {'split:ho', 'kernel:linear', 'paramsel:hodual', 'rls:svmsubgradient', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
+        opt.process{1} = [2,2,2,2,0,0,0];
+        opt.process{2} = [3,3,3,3,2,2,2];
+        opt.epochs = 100;
+        gurls(Xtr, ytr, opt, 1);
+        op = gurls(Xte, yte, opt, 2);
+        disp(op.perf.acc);
+    end
+
+    strind = strmatch('rbfsvmsub',filestr);
+    if ~isempty(strind)
+        % Gaussian kernel, SVM Subgradient, Hold Out cross validation to select lambda and the Kernel width sigma
+        name = [filestr{strind} '_' num2str(r)];
+        opt = defopt(name);
+        opt.seq = {'split:ho', 'paramsel:siglamho', 'kernel:rbf', 'rls:svmsubgradient', 'predkernel:traintest', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
+        opt.process{1} = [2,2,2,2,0,0,0,0];
+        opt.process{2} = [3,3,3,3,2,2,2,2];
+        opt.epochs = 100;
+        gurls(Xtr, ytr, opt, 1);
+        op = gurls(Xte, yte, opt, 2);
+        disp(op.perf.acc);
+    end
+
+    strind = strmatch('rbfho',filestr);
+    if ~isempty(strind)
+        % Gaussian kernel, (dual formulation), Hold Out cross validation to select lambda and the Kernel width sigma
+        name = [filestr{strind} '_' num2str(r)];
+        opt = defopt(name);
+        opt.seq = {'split:ho', 'paramsel:siglamho', 'kernel:rbf', 'rls:dual', 'predkernel:traintest', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
+        opt.process{1} = [2,2,2,2,0,0,0,0];
+        opt.process{2} = [3,3,3,3,2,2,2,2];
+        gurls(Xtr, ytr, opt, 1);
+        gurls(Xte, yte, opt, 2); 
+    end
+    
+    strind = strmatch('rbfloo',filestr);
+    if ~isempty(strind)
+        % Gaussian kernel, (dual formulation), Leave One Out cross validation to select lambda and the Kernel width sigma
+        name = [filestr{strind} '_' num2str(r)];
+        opt = defopt(name);
+        opt.seq = {'paramsel:siglam', 'kernel:rbf', 'rls:dual', 'predkernel:traintest', 'pred:dual', 'perf:macroavg', 'perf:precrec'};
+        opt.process{1} = [2,2,2,0,0,0,0];
+        opt.process{2} = [3,3,3,2,2,2,2];
+        gurls(Xtr, ytr, opt, 1);
+        gurls(Xte, yte, opt, 2);
+    end
+end
+
+%% Visualization:
+%	- filestr: cell with names of the experiments
+%	- nRuns: number of runs for each experiment
+%	- fields: which fields of opt to display (as many plots as the elements of fields will be generated).
+%	- plotopt: a structure containing various text labels for the plots.
+
+nRuns = n*ones(1,length(filestr));
+fields = {'perf.ap', 'perf.acc'};
+plotopt.titles = {'Model Comparison - Accuracy', 'Model Comparison - Precision'};
+
+if strcmp(dataset,'breastcancer')
+    plotopt.class_names = {'Positive'};
+elseif strcmp(dataset,'yeast')
+    plotopt.class_names = {'CYT', 'NUC', 'MIT', 'ME3'};
+end
+
+% Generates "per-class" plots
+summary_plot(filestr, fields, nRuns, plotopt, res_root)
+% Generates "global" plots
+summary_overall_plot(filestr, fields, nRuns, plotopt, res_root)
+% Plots times taken by each step of the pipeline for performance reference.
+plot_times(filestr, nRuns, res_root)
+

--- a/gurls/demo/demo_svmsubgradient.m
+++ b/gurls/demo/demo_svmsubgradient.m
@@ -16,7 +16,7 @@ models = {'linsvmsub','rbfsvmsub','rbfho','rbfloo'};
 % Number of trials to run each method
 n = 5;
 
-res_root = fullfile(gurls_root, 'demo/demodata'); % location where res files are stored
+res_root = fullfile(gurls_root, 'demo'); % location where res files are stored
 
 for r = 1:n
     strind = strmatch('linsvmsub',models);

--- a/gurls/gurls_defopt.m
+++ b/gurls/gurls_defopt.m
@@ -65,6 +65,7 @@ function opt = gurls_defopt(expname)
     
     %% Subgradient
     opt.newprop( 'Niter', 100);
+    opt.newprop( 'gammafunc', @(x) power(x,-1));
 
     %% Random features options
     opt.newprop( 'randfeats', struct());

--- a/gurls/gurls_defopt.m
+++ b/gurls/gurls_defopt.m
@@ -62,6 +62,9 @@ function opt = gurls_defopt(expname)
     opt.newprop( 'epochs', 4);
     opt.newprop( 'subsize', 50);
     opt.newprop( 'calibfile', 'foo');
+    
+    %% Subgradient
+    opt.newprop( 'Niter', 100);
 
     %% Random features options
     opt.newprop( 'randfeats', struct());

--- a/gurls/optimizers/rls_svmsubgradient.m
+++ b/gurls/optimizers/rls_svmsubgradient.m
@@ -11,6 +11,8 @@ function [rls] = rls_svmsubgradient(X,y, opt)
 %   fields with default values set through the defopt function:
 %		- singlelambda
 %       - Niter
+%       - gammafunc - the function that maps niter to step factor, gamma
+%                     the default is 1/niter --> [1, 1/2, 1/3, ... 1/Niter]
 % 
 %   For more information on standard OPT fields
 %   see also defopt
@@ -39,7 +41,7 @@ else
 end
 
 iter = niter:(Niter);
-gamma = 1./iter;
+gamma = opt.gammafunc(iter);
 
 for i = iter;
     yhat = opt.kernel.K*alpha;

--- a/gurls/optimizers/rls_svmsubgradient.m
+++ b/gurls/optimizers/rls_svmsubgradient.m
@@ -1,0 +1,64 @@
+function [rls] = rls_svmsubgradient(X,y, opt)
+
+% rls_svmsubgradient(X, y, opt)
+% computes the regression function for svm subgradient method.
+% The regularization parameter (i.e. the number of iterations) is set to the one found in opt.paramsel.
+%
+% INPUTS:
+% -OPT: struct of options with the following fields:
+%   fields that need to be set through previous gurls tasks:
+%		- paramsel.lambdas (set by the paramsel_* routines)
+%   fields with default values set through the defopt function:
+%		- singlelambda
+% 
+%   For more information on standard OPT fields
+%   see also defopt
+% 
+% OUTPUT: struct with the following fields:
+% -W: matrix of coefficient vectors of rls estimator for each class
+% -C: empty matrix
+% -X: empty matrix
+
+lambda = opt.singlelambda(opt.paramsel.lambdas);
+Niter = opt.Niter;
+
+[n,T] = size(y);
+
+if isfield(opt.paramsel,'niter');
+    niter = max(1,ceil(opt.paramsel.niter));
+else
+    niter = 1;
+end
+
+if isfield(opt.paramsel,'f0') && niter <= Niter;
+    alpha = opt.paramsel.f0;
+else
+    niter = 1;
+    alpha=zeros(n,T);
+end
+
+iter = niter:(Niter);
+gamma = 1./iter;
+
+for i = iter;
+    yhat = opt.kernel.K*alpha;
+    yxyhat = y.*yhat;
+    indic = (yxyhat <= 1);
+    alpha = alpha*(1-2*gamma(i)*lambda) + (gamma(i)/n)*(y.*indic);
+end
+
+opt.paramsel.f0 = alpha;
+opt.paramsel.niter = Niter;
+
+if strcmp(opt.kernel.type, 'linear')
+	rls.W = X'*alpha;
+	rls.C = [];
+	rls.X = [];
+else
+	rls.W = [];
+    rls.C = alpha;
+	rls.X = X;
+end
+
+
+

--- a/gurls/optimizers/rls_svmsubgradient.m
+++ b/gurls/optimizers/rls_svmsubgradient.m
@@ -2,14 +2,15 @@ function [rls] = rls_svmsubgradient(X,y, opt)
 
 % rls_svmsubgradient(X, y, opt)
 % computes the regression function for svm subgradient method.
-% The regularization parameter (i.e. the number of iterations) is set to the one found in opt.paramsel.
-%
+% The regularization parameter is set to the one found in opt.paramsel (set by the paramsel_* routines)
+
 % INPUTS:
 % -OPT: struct of options with the following fields:
 %   fields that need to be set through previous gurls tasks:
 %		- paramsel.lambdas (set by the paramsel_* routines)
 %   fields with default values set through the defopt function:
 %		- singlelambda
+%       - Niter
 % 
 %   For more information on standard OPT fields
 %   see also defopt


### PR DESCRIPTION
Wrote SVM Subgradient script with demo function
Follows the kernel formulation
Demo runs both RBF and Linear kernels to show off SVM Sub functionality and compares to dual RLS formulation.  The other methods can be easily configured in the demo script.

Requires addition of two parameters for defopt:
1) 'Niter' - the total number of iterations of subgradient descent 
2) 'gammafunc' - the function that maps the iteration number to the step size

Notes:
Reuses the Dual RLS prediction code - might want to create a new one, if that suits convention better
Can be adapted to use Matlab sparse matrices to take even better advantage of SVM sparsity.
